### PR TITLE
31 symbolic variables

### DIFF
--- a/documentation/User_Documentation.md
+++ b/documentation/User_Documentation.md
@@ -93,7 +93,7 @@ NOP
 .CODE
 ```
 
-In the current implementation the string is encoded in UTF-8 and stored in a null terminated array in the code segment of the CPU-Simulator like the symbolic string constants. For more details see [1.1.2 Symbolic String Constants](#112-symbolic-string-constants) and the warning [above](#12-symbolic-variables).
+In the current implementation the string is encoded in UTF-8 and stored in a null terminated array in the code segment of the CPU-Simulator like the symbolic string constants. The `NOP` instruction is modified and needed to switch the program into kernel mode. For more details see [1.1.2 Symbolic String Constants](#112-symbolic-string-constants) and the warning [above](#12-symbolic-variables).
 
 The assembler replaces the symbolic name of the string variables in the assembly code with their virtual memory address. The virtual memory address is the start address of the string array. The symbolic name can be used like a normal memory address.
 

--- a/documentation/User_Documentation.md
+++ b/documentation/User_Documentation.md
@@ -9,8 +9,7 @@
 Symbolic integer constants can store a 32 bit integer value and can be defined as follows:
 
 ``` Assembly
-const myIntConst = 5
-const myIntConst=5
+.CONST myIntConst 5
 ```
 
 The assembler stores the integer value and replaces all occurrences of the symbolic integer constant in the assembly code with their actual value.
@@ -29,8 +28,7 @@ This writes the value 5 into the EAX register.
 Symbolic string constants are treated a bit differently than symbolic integer constants and can be defined as follows:
 
 ``` Assembly
-const myStringConst = "I am a string."
-const myStringConst="I am a string."
+.CONST myStringConst "I am a string."
 ```
 
 The given string is stored as a UTF-8 encoded and null terminated array in the code segment of the CPU-Simulator.

--- a/documentation/User_Documentation.md
+++ b/documentation/User_Documentation.md
@@ -1,0 +1,121 @@
+# Ihme-Core CPU Simulator User Manual
+
+## 1 Writing Assembly Code for the CPU Simulator
+
+## 1.1 Symbolic Constants
+
+### 1.1.1 Symbolic Integer Constants
+
+Symbolic integer constants can store a 32-Bit integer value and can be defined as follows:
+
+``` Assembly
+const myIntConst = 5
+const myIntConst=5
+```
+
+The assembler stores the integer value and replaces all occurrences of the symbolic integer constant in the assembly code with their actual value.
+
+The symbolic name of the integer constant can then be used like a normal integer value in the assembly code.
+Here is an example of writing the previously defined integer constant into the EAX register:
+
+``` Assembly
+MOV $myIntConst, %eax
+```
+
+This writes the value 5 into the EAX register.
+
+### 1.1.2 Symbolic String Constants
+
+Symbolic string constants are treated a bit differently than symbolic integer constants and can be defined as follows:
+
+``` Assembly
+const myStringConst = "I am a string."
+const myStringConst="I am a string."
+```
+
+The given string is stored as UTF-8 encoded and null terminated array in the code segment of the CPU-Simulator.
+
+In case that the encoded string is not divisible by four byte, an additional four byte are used for the rest of the string. This is due to the current CPU-Simulator design using fixed 32-Bit instructions and operands. The rest of the four byte that are unused get filled by zeroes, so some memory overhead is expected.
+
+Being stored in the code segment makes the string constant as the code segment is write protected in user mode and only writeable in kernel mode. To not interrupt the code execution a jump instruction is automatically placed in front of the string array. The target of the jump instruction is the first virtual memory address after the string array.
+
+The assembler replaces the symbolic name of the string constant with the virtual memory start address of the string array. The array goes from the lowest virtual memory address to the highest virtual memory address.
+
+The symbolic name of the string constant can then be used like a memory address in the assembly code.
+Here is an example of writing the (start) virtual memory address of the previously defined string constant into the EAX register:
+
+``` Assembly
+MOV $myStringConst, %EAX
+```
+
+In the current implementation the constants can be misused as variables, see the warning [below](#12-symbolic-variables).
+
+## 1.2 Symbolic Variables
+
+:warning:**Caution:** In the current implementation the symbolic integer and string variables are stored in the code segment. The code segment is write protected in user mode and only writeable in kernel mode. To assign different values to the variables during program runtime, the program has to switch into kernel mode. Under normal circumstances the program should not be able to to switch into kernel mode directly. To make the variables work correctly a modified NOP instruction has bee included, which switches the program into kernel mode. The NOP instruction has to be used once before variables can be assigned a new value (see the examples below). The modified NOP instruction is needed until a data segment or something of similar function is implemented.
+
+Using the modified NOP instruction also makes constants behave like variables, so caution is advised.
+
+### 1.2.1 Symbolic Integer Variables
+
+Symbolic integer variables can store a 32-Bit integer value. They can be created as follows:
+
+``` Assembly
+NOP
+.DATA
+.intVariable ;uninitialized integer variable
+.intVariableWithValue 5 ;creates integer variable with the value 5
+.CODE
+```
+
+Defining and declaring symbolic integer variables always has to be done between the `.DATA` and the `.CODE` blocks. The variable gets initialized with zero internally if no value is given, like shown for the first variable above, otherwise it gets initialized with the given numerical value.
+The assembler encodes the integer variable as 32-Bit integer and stores it in the code segment of the CPU-Simulator. To not interrupt the program flow a jump instruction is automatically added by the assembler in front of the integer variable in virtual memory. The jump target is the first virtual memory address after the integer variable.
+The assembler replaces all occurrences of the symbolic name of the integer variable with their virtual memory address.
+The `NOP` instruction switches the program into kernel mode, see the warning [above](#12-symbolic-variables).
+
+Reassigning the value of a symbolic integer variable can be done as follows:
+
+```Assembly
+MOV $10, @intVariable
+```
+
+In the above example the value 10 is assigned to the symbolic integer variable `intVariable`.
+The symbolic name can be used like a normal memory address.
+
+### 1.2.2 Symbolic String Variables
+
+Symbolic string variables are used to store a string as a null terminated array in memory. They can be defined as follows:
+
+``` Assembly
+NOP
+.DATA
+.stringVariable "I am a string."
+.CODE
+```
+
+In the current implementation the string is encoded in UTF-8 and stored in a null terminated array in the code segment of the CPU-Simulator like the symbolic string constants. For more details see [1.1.2 Symbolic String Constants](#112-symbolic-string-constants) and the warning [above](#12-symbolic-variables).
+
+The assembler replaces the symbolic name of the string variables in the assembly code with their virtual memory address. The virtual memory address is the start address of the string array. The symbolic name can be used like a normal memory address.
+
+```Assembly
+MOV $stringVariable, %eax
+```
+
+In the above example the virtual memory start address of the `stringVariable` gets written into the EAX register.
+
+## 2 GUI
+
+## 2.1 Registers
+
+### 2.1.1 Clickable Registers
+
+Some registers can hold memory addresses either for the virtual or for the physical memory. A feature has been implemented that allows the user to jump to those memory addresses by clicking on the GUI element of the register. The memory cell in the virtual or physical memory gets highlighted after the jump. This minimizes the scrolling necessary and makes it easier to find those memory address easier.
+Following registers implement the jump on click feature:
+
+- EAX
+- EBX
+- ECX
+- ESP
+- EIP
+- ITP
+- PTP

--- a/documentation/User_Documentation.md
+++ b/documentation/User_Documentation.md
@@ -45,7 +45,7 @@ The symbolic name of the string constant can then be used like a memory address 
 Here is an example of writing the (start) virtual memory address of the previously defined string constant into the EAX register:
 
 ``` Assembly
-MOV $myStringConst, %EAX
+MOV $myStringConst, %eax
 ```
 
 In the current implementation the constants can be misused as variables, see the warning [below](#12-symbolic-variables).

--- a/documentation/User_Documentation.md
+++ b/documentation/User_Documentation.md
@@ -6,7 +6,7 @@
 
 ### 1.1.1 Symbolic Integer Constants
 
-Symbolic integer constants can store a 32-Bit integer value and can be defined as follows:
+Symbolic integer constants can store a 32 bit integer value and can be defined as follows:
 
 ``` Assembly
 const myIntConst = 5
@@ -33,13 +33,13 @@ const myStringConst = "I am a string."
 const myStringConst="I am a string."
 ```
 
-The given string is stored as UTF-8 encoded and null terminated array in the code segment of the CPU-Simulator.
+The given string is stored as a UTF-8 encoded and null terminated array in the code segment of the CPU-Simulator.
 
-In case that the encoded string is not divisible by four byte, an additional four byte are used for the rest of the string. This is due to the current CPU-Simulator design using fixed 32-Bit instructions and operands. The rest of the four byte that are unused get filled by zeroes, so some memory overhead is expected.
+In case that the length of the encoded string is not divisible by four bytes, its storage is rounded up to a multiple of four bytes. This is due to the current CPU simulator design using fixed 32 bit instructions and operands. The unused rest of the four bytes storage at the end of such a string is filled by bytes with a zero value, so some memory overhead is expected.
 
-Being stored in the code segment makes the string constant as the code segment is write protected in user mode and only writeable in kernel mode. To not interrupt the code execution a jump instruction is automatically placed in front of the string array. The target of the jump instruction is the first virtual memory address after the string array.
+Being stored in the code segment makes the string constant as the code segment is write protected in user mode and only writeable in kernel mode. To not interrupt the code execution, a jump instruction is automatically placed in front of the string array. The target of the jump instruction is the first virtual memory address after the string array.
 
-The assembler replaces the symbolic name of the string constant with the virtual memory start address of the string array. The array goes from the lowest virtual memory address to the highest virtual memory address.
+The assembler replaces the symbolic name of the string constant with the virtual memory start address of the string array. The encoding of the first character in the string starts at the lowest virtual memory address.
 
 The symbolic name of the string constant can then be used like a memory address in the assembly code.
 Here is an example of writing the (start) virtual memory address of the previously defined string constant into the EAX register:
@@ -52,7 +52,7 @@ In the current implementation the constants can be misused as variables, see the
 
 ## 1.2 Symbolic Variables
 
-:warning:**Caution:** In the current implementation the symbolic integer and string variables are stored in the code segment. The code segment is write protected in user mode and only writeable in kernel mode. To assign different values to the variables during program runtime, the program has to switch into kernel mode. Under normal circumstances the program should not be able to to switch into kernel mode directly. To make the variables work correctly a modified NOP instruction has bee included, which switches the program into kernel mode. The NOP instruction has to be used once before variables can be assigned a new value (see the examples below). The modified NOP instruction is needed until a data segment or something of similar function is implemented.
+:warning:**Caution:** In the current implementation the symbolic integer and string variables are stored in the code segment. The code segment is write protected in user mode and only writeable in kernel mode. To assign different values to the variables during program runtime, the program has to switch into kernel mode. Under normal circumstances the program should not be able to switch into kernel mode directly. To make the variables work correctly, a modified NOP instruction has been implemented as a work-around, which switches the program into kernel mode. This NOP instruction has to be used once before variables can be assigned a new value (see the examples below). The modified NOP instruction is needed until a (writable) data segment or some other way of holding the variables in writable storage is implemented. 
 
 Using the modified NOP instruction also makes constants behave like variables, so caution is advised.
 
@@ -68,9 +68,9 @@ NOP
 .CODE
 ```
 
-Defining and declaring symbolic integer variables always has to be done between the `.DATA` and the `.CODE` blocks. The variable gets initialized with zero internally if no value is given, like shown for the first variable above, otherwise it gets initialized with the given numerical value.
-The assembler encodes the integer variable as 32-Bit integer and stores it in the code segment of the CPU-Simulator. To not interrupt the program flow a jump instruction is automatically added by the assembler in front of the integer variable in virtual memory. The jump target is the first virtual memory address after the integer variable.
-The assembler replaces all occurrences of the symbolic name of the integer variable with their virtual memory address.
+Defining and declaring symbolic integer variables always has to be done between the `.DATA` and the `.CODE` blocks. The variable is initialized with zero internally if no value is given, like shown for the first variable above, otherwise it is initialized with the given numerical value.
+The assembler encodes the integer variable as a 32 bit integer and stores it in the code segment of the CPU simulator. To not interrupt the program flow, a jump instruction is automatically added by the assembler in front of the integer variable in virtual memory. The jump target is the first virtual memory address after the integer variable.
+The assembler replaces all occurrences of the symbolic name of the integer variable with its virtual memory address.
 The `NOP` instruction switches the program into kernel mode, see the warning [above](#12-symbolic-variables).
 
 Reassigning the value of a symbolic integer variable can be done as follows:
@@ -84,7 +84,7 @@ The symbolic name can be used like a normal memory address.
 
 ### 1.2.2 Symbolic String Variables
 
-Symbolic string variables are used to store a string as a null terminated array in memory. They can be defined as follows:
+Symbolic string variables are used to store a string in memory. They can be defined as follows:
 
 ``` Assembly
 NOP
@@ -93,15 +93,15 @@ NOP
 .CODE
 ```
 
-In the current implementation the string is encoded in UTF-8 and stored in a null terminated array in the code segment of the CPU-Simulator like the symbolic string constants. The `NOP` instruction is modified and needed to switch the program into kernel mode. For more details see [1.1.2 Symbolic String Constants](#112-symbolic-string-constants) and the warning [above](#12-symbolic-variables).
+In the current implementation the string is encoded in UTF-8 and stored in a null terminated array of bytes in the code segment of the CPU-Simulator like the symbolic string constants. Again, the `NOP` instruction is modified and needed to switch the program into kernel mode. For more details see [1.1.2 Symbolic String Constants](#112-symbolic-string-constants) and the warning [above](#12-symbolic-variables).
 
-The assembler replaces the symbolic name of the string variables in the assembly code with their virtual memory address. The virtual memory address is the start address of the string array. The symbolic name can be used like a normal memory address.
+The assembler replaces the symbolic name of the string variables in the assembly code with their virtual memory address. The virtual memory address is the start address of the array of bytes that encodes the string. The symbolic name can be used like a normal memory address.
 
 ```Assembly
 MOV $stringVariable, %eax
 ```
 
-In the above example the virtual memory start address of the `stringVariable` gets written into the EAX register.
+In the above example the virtual memory start address of the `stringVariable` is written into the EAX register.
 
 ## 2 GUI
 
@@ -110,7 +110,7 @@ In the above example the virtual memory start address of the `stringVariable` ge
 ### 2.1.1 Clickable Registers
 
 Some registers can hold memory addresses either for the virtual or for the physical memory. A feature has been implemented that allows the user to jump to those memory addresses by clicking on the GUI element of the register. The memory cell in the virtual or physical memory gets highlighted after the jump. This minimizes the scrolling necessary and makes it easier to find those memory address easier.
-Following registers implement the jump on click feature:
+The following registers implement the jump on click feature:
 
 - EAX
 - EBX

--- a/settings/language_definition.json
+++ b/settings/language_definition.json
@@ -1,6 +1,13 @@
-{
+{   
+    "variable_formats" : {
+        "dataSegmentStart" : "\\.DATA",
+        "dataSegmentEnd" : "\\.CODE",
+        "integerVariable" : "^\\.[a-zA-Z][a-zA-Z\\-_0-9]*[ ]?-?[0-9]*$",
+        "stringVariable" : "^\\.[a-zA-Z][a-zA-Z\\-_0-9]*[ ]\"[a-zA-Z0-9]*\"$",
+        "usage" : "[$%@][a-zA-Z][a-zA-Z\\-_0-9]*"
+    },
     "constant_formats" : {
-        "declarationInteger" : "^const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?[0-9]*$",
+        "declarationInteger" : "^const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?-?[0-9]*$",
         "declarationString" : "^const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?\"[a-zA-Z0-9]*\"$",
         "usage" : "[$%@][a-zA-Z][a-zA-Z\\-_0-9]*"
     },

--- a/settings/language_definition.json
+++ b/settings/language_definition.json
@@ -7,8 +7,8 @@
         "usage" : "[$%@][a-zA-Z][a-zA-Z\\-_0-9]*"
     },
     "constant_formats" : {
-        "declarationInteger" : "^const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?-?[0-9]*$",
-        "declarationString" : "^const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?\"[a-zA-Z0-9]*\"$",
+        "declarationInteger" : "^.CONST[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]-?[0-9]+$",
+        "declarationString" : "^.CONST[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]\"[a-zA-Z0-9]*\"$",
         "usage" : "[$%@][a-zA-Z][a-zA-Z\\-_0-9]*"
     },
     "comment_format" : "[ ]*;.*",

--- a/src/main/simulator/Assembler.ts
+++ b/src/main/simulator/Assembler.ts
@@ -44,42 +44,22 @@ export class Assembler {
 	}
 
 	/**
-	 * This method locates and removes the jump labels from the assembly code.
-	 * @param lines The lines of code to search for jump labels.
-	 * @returns The lines of code without jump labels.
-	 */
-	private removeJumpLabels(lines: Map<number, string>): Map<number, string> {
-		// Locate jump labels and put them into the list of lines to delete.
-		const lineNumbersMarkedForDeletion: number[] = [];
-		for (const [lineNo, line] of lines.entries()) {	
-			if (line.match(new RegExp(this.languageDefinition.label_formats.declaration, "gim"))) {
-				lineNumbersMarkedForDeletion.push(lineNo);
-			}
-		}
-		// Remove jump labels from the list of lines.
-		for (const lineNo of lineNumbersMarkedForDeletion) {
-			lines.delete(lineNo);
-		}
-		return lines;
-	}
-
-	/**
 	 * This method encodes the reduced assembly program to its binary equivalent.
 	 * @param lines A map, which maps line numbers to strings representing the original programs lines of code.
 	 * @returns An array of doublewords representing the encoded instructions and their operands of the assembly program.
 	 */
 	private encode(lines: Map<number, string>): DoubleWord[] {
 		const encodedInstructions: DoubleWord[] = [];
-		const constants: Map<string, string> = this.locateConstants(lines);
-		const replacedConstants: Map<number, string> = this.replaceConstants(lines, constants);
-		const jumpLabels: Map<string, string> = this.locateJumpLabels(replacedConstants);	
+		const constants: Map<string, string> = new Map();
+		const variables: Map<string, string> = new Map();
+		const jumpLabels: Map<string, string> = new Map();
 
-		// Remove jump labels as they will not be encoded.
-		lines = this.removeJumpLabels(lines);
+		this.locateSymbols(lines, jumpLabels, constants, variables);
+		this.replaceSymbols(lines, constants, variables);
 		
 		// Iterate lines of code.
 		for (const [lineNo, line] of lines.entries()) {
-			const encodedInstruction: DoubleWord[] = this.encodeLine(lineNo, line, jumpLabels, constants);
+			const encodedInstruction: DoubleWord[] = this.encodeLine(lineNo, line, jumpLabels, constants, variables);
 			encodedInstructions.push(...encodedInstruction);	
 		}
 		return encodedInstructions;
@@ -91,9 +71,10 @@ export class Assembler {
 	 * @param line The original computer programs line of code which is currently encoded.
 	 * @param jumpLabels The jump labels found in the assembly code.
 	 * @param constants The constants found in the assembly code.
+	 * @param variables The constants found in the assembly code.
 	 * @returns An array of doublewords representing the encoded instructions and their operands of the assembly program.
 	 */
-	private encodeLine(lineNo: number, line: string, jumpLabels: Map<string, string>, constants: Map<string, string>) : DoubleWord[] {
+	private encodeLine(lineNo: number, line: string, jumpLabels: Map<string, string>, constants: Map<string, string> = new Map(), variables: Map<string, string> = new Map()) : DoubleWord[] {
 		const encodedInstructions: DoubleWord[] = [];
 		let lineEncoded = false;
 		lineEncoded = false;
@@ -191,9 +172,40 @@ export class Assembler {
 			}
 		}
 		if (line.match(new RegExp(this.languageDefinition.constant_formats.declarationString, "gim"))) {
-			const encodedInstruction: DoubleWord[] = this.encodeString(lineNo, line, jumpLabels, constants);
-			encodedInstructions.push(...encodedInstruction);
-			lineEncoded = true;
+			const stringConstantName = line.replace(/const[ ]|[ ]?=[ ]?".*/gim, "");
+			const stringConstantValue = line.replace(/const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?|"/gim, "") + "\0";
+			if (constants.has(stringConstantName)) {
+				const stringConstantAddress = constants.get(stringConstantName)!;
+				const encodedInstruction: DoubleWord[] = this.encodeString(lineNo, line, jumpLabels, stringConstantValue, stringConstantAddress);
+				encodedInstructions.push(...encodedInstruction);
+				lineEncoded = true;
+			}
+		} else if (line.match(new RegExp(this.languageDefinition.variable_formats.stringVariable, "gim"))) {
+			const stringVariableName = line.replace(/^\.|[ ]".*/gim, "");
+			const stringVariableValue = line.replace(/^\.[a-zA-Z][a-zA-Z\\-_0-9]*[ ]"|"$/gim, "") + "\0"; 
+			if (variables.has(stringVariableName)) {
+				const stringVariableAddress = variables.get(stringVariableName)!;
+				const encodedInstruction: DoubleWord[] = this.encodeString(lineNo, line, jumpLabels, stringVariableValue, stringVariableAddress);
+				encodedInstructions.push(...encodedInstruction);
+				lineEncoded = true;
+			}
+		} else if (line.match(new RegExp(this.languageDefinition.variable_formats.integerVariable))) {
+			const variableName = line.replace(/^\.|[ ][0-9]*$/gim, "");
+			const variableValue = line.replace(/^\.[a-zA-Z][a-zA-Z\\-_0-9]*[ ]?/gim, "");
+			if (variables.has(variableName)) {
+				const variableStartAddress: string = variables.get(variableName)!.replace(/^0b/gim, "");;
+				//The memory address after the Integer with the next instruction
+				const jumpAddress:string = VirtualAddress.fromInteger(parseInt(variableStartAddress, 2) + 4).toString();
+				const jumpInstruction:string = "JMP @0b" + jumpAddress;
+				const encodedInstruction: DoubleWord[] = this.encodeLine(-1, jumpInstruction, jumpLabels);
+				if (variableValue !== "") {
+					encodedInstruction.push(this.encodeDecimalValue(variableValue, lineNo));
+				} else {
+					encodedInstruction.push(this.encodeDecimalValue("0", lineNo));
+				}
+				encodedInstructions.push(...encodedInstruction);
+				lineEncoded = true;
+			}
 		}
 		if (!lineEncoded) {
 			throw new UnrecognizedInstructionError(`Unrecognized or invalid instruction found in line ${lineNo + 1}: ${line}`);
@@ -202,13 +214,15 @@ export class Assembler {
 	}
 
 	/**
-	 * This method locates jump labels in the assembly code and creates a map between a jump label and a (virtual) memory address.
-	 * This map is later used to replace the label in instructions with their (virtual) memory address.
+	 * Locates the jump labels, constants and variables in the assembly code.
+	 * For the jump labels, integer and string variables and string constants a map is created between their symbolic name and a (virtual) memory address.
+	 * For integer constants their symbolic name gets mapped to their value.
 	 * @param lines A map, which maps line numbers to strings representing the original programs lines of code.
-	 * @returns A map of jump labels and their associated (virtual) memory address.
+	 * @param jumpLabels A map for the jump labels and their associated (virtual) memory address.
+	 * @param constants A map for the constants and their associated (virtual) memory address or value in case of integers.
+	 * @param variables A map for the variables and their associated (virtual) memory address.
 	 */
-	private locateJumpLabels(lines: Map<number, string>) : Map<string, string> {
-		const jumpLabels: Map<string, string> = new Map();
+	private locateSymbols(lines: Map<number, string>, jumpLabels: Map<string, string>, constants: Map<string, string>, variables: Map<string, string>) : void {
 		/**
 		 * Use this variable in order to count the instructions, that need to be encoded
 		 * later, because the keys in the map do not have to be consecutive, as blank lines 
@@ -216,45 +230,9 @@ export class Assembler {
 		 */
 		let programLocationCounter = 0;
 		for (const [lineNo, line] of lines.entries()) {
-			if (line.match(new RegExp(this.languageDefinition.label_formats.declaration, "gim"))) {
-				const jumpLabel = line.replace(/\.|:/gim, "");
-				jumpLabels.set(
-					jumpLabel, 
-					VirtualAddress.fromInteger(programLocationCounter).toString()
-				);
-			} else if (line.match(new RegExp(this.languageDefinition.constant_formats.declarationString, "gim"))) {
-				//If a string constant is found, skip as many memory cells as needed to fit all characters plus null terminator 
-				//plus one instruction for the jump instruction.
-				const constValue = line.replace(/const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?|"/gim, "") + "\0";
-				//Calculate the size the string will use in memory including null termination and round up to the next size that
-				//is divisible by four. This insures the string always fits into multiple double words.
-				const stringMemSize = Math.ceil((Buffer.byteLength(constValue) / 4)) * 4;
-				programLocationCounter += stringMemSize + 12;
-			} else {
-				programLocationCounter += 12;
-			}
-		}
-		return jumpLabels;
-	}
-
-	/**
-	 * This method finds constants and stores their value in a map with their constant name.
-	 * If the constant is a string then a (virtual) memory address is mapped to the constant name instead.
-	 * The created map is later used to replace constants by name with their actual value or (virtual) memory address.
-	 * The line that initializes an integer constant is deleted as it doesn't get translated.
-	 * @param lines A map, which maps line numbers to strings representing the original programs lines of code.
-	 * @returns A map of integer constants and their value.
-	 */
-	private locateConstants(lines: Map<number, string>) : Map<string, string> {
-		const constants: Map<string, string> = new Map();
-		/**
-		 * Use this variable in order to count the instructions, that need to be encoded
-		 * later, because the keys in the map do not have to be consecutive, as blank lines 
-		 * have been removed from the original source text.
-		 */
-		let programLocationCounter = 0;
-		for (const [lineNo, line] of lines.entries()) {
-			if (line.match(new RegExp(this.languageDefinition.constant_formats.declarationInteger, "gim"))) {
+			if (line.match(new RegExp(this.languageDefinition.variable_formats.dataSegmentStart)) || line.match(new RegExp(this.languageDefinition.variable_formats.dataSegmentEnd))) {
+				lines.delete(lineNo);
+			} else if (line.match(new RegExp(this.languageDefinition.constant_formats.declarationInteger, "gim"))) {
 				const constantName = line.replace(/const[ ]|[ ]?=[ ]?[0-9]*/gim, "");
 				const constantValue = line.replace(/const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?/gim, "");
 				constants.set(
@@ -274,26 +252,66 @@ export class Assembler {
 				//is divisible by four. This insures the string always fits into multiple double words.
 				const stringMemSize = Math.ceil((Buffer.byteLength(constantValue) / 4)) * 4;
 				programLocationCounter += stringMemSize + 12;
+			} else if (line.match(new RegExp(this.languageDefinition.variable_formats.integerVariable))) {
+				const variableName = line.replace(/^.|[ ][0-9]*$/gim, "");
+				//programLocationCounter +12 since the jump instruction will be located in front of the integer memory address.
+				variables.set(
+					variableName,
+					"0b" + VirtualAddress.fromInteger(programLocationCounter+12).toString()
+				);
+				//Size of jump instruction plus 32bit integer
+				programLocationCounter += 16;
+			} else if (line.match(new RegExp(this.languageDefinition.variable_formats.stringVariable))) {
+				const variableName = line.replace(/^.|[ ]".*/gim, "");
+				const variableValue = line.replace(/^\.[a-zA-Z][a-zA-Z\\-_0-9]*[ ]"|"$/gim, "") + "\0";
+				variables.set(
+					variableName,
+					"0b" + VirtualAddress.fromInteger(programLocationCounter+12).toString()
+				)
+				//Calculate the size the string will use in memory including null termination and round up to the next size that
+				//is divisible by four. This insures the string always fits into multiple double words.
+				const stringMemSize = Math.ceil((Buffer.byteLength(variableValue) / 4)) * 4;
+				programLocationCounter += stringMemSize + 12;
+			} else if (line.match(new RegExp(this.languageDefinition.label_formats.declaration, "gim"))) {
+				const jumpLabel = line.replace(/\.|:/gim, "");
+				jumpLabels.set(
+					jumpLabel, 
+					VirtualAddress.fromInteger(programLocationCounter).toString()
+				);
+				lines.delete(lineNo);
 			} else {
 				programLocationCounter += 12;
 			}
 		}
-		return constants;
 	}
 
 	/**
-	 * This method locates and removes the constants in the program code and replaces them with their value or with their (virtual) memory start address.
-	 * @param lines The lines of code to search for constants.
-	 * @returns The lines of code without jump labels.
+	 * This method finds the usage of symbolic names for the constants and variables in the assembly code and replaces them.
+	 * Integer constants get replaced by their value while string constants, string variables and integer variables get replaced by their
+	 * (virtual) memory start address.
+	 * @param lines A map, which maps line numbers to strings representing the original programs lines of code.
+	 * @param constants A map for the constants and their associated (virtual) memory address or value in case of integers.
+	 * @param variables A map for the variables and their associated (virtual) memory address.
+	 * @returns 
 	 */
-	private replaceConstants(lines: Map<number, string>, integerConstants: Map<string, string>): Map<number, string> {
+	private replaceSymbols(lines: Map<number, string>, constants: Map<string, string>, variables: Map<string, string>) : Map<number, string> {
 		for (const [lineNo, line] of lines.entries()) {	
 			if (line.match(new RegExp(this.languageDefinition.constant_formats.usage, "gim"))) {
 				//Test if constant name is included in line and replace it with its value
-				integerConstants.forEach((constantValue, constantName) => {
+				constants.forEach((constantValue, constantName) => {
 					const regex = new RegExp("[$%@]" + constantName , "m");
 					if (line.match(regex) !== null) {
 						const replacedLine = line.replace(constantName,constantValue);
+						lines.set(lineNo, replacedLine);
+					}
+				});
+			}
+			if (line.match(new RegExp(this.languageDefinition.variable_formats.usage, "gim"))) {
+				//Test if variable name is included in line and replace it with its value
+				variables.forEach((variableValue, variableName) => {
+					const regex = new RegExp("[$%@]" + variableName , "m");
+					if (line.match(regex) !== null) {
+						const replacedLine = line.replace(variableName,variableValue);
 						lines.set(lineNo, replacedLine);
 					}
 				});
@@ -310,51 +328,27 @@ export class Assembler {
 	 * @param constants A map of the names of constants and their corresponding value in case of integer or (virtual) memory start address in case of strings.
 	 * @returns An array containing the binary equivalent of the given instruction and its operand values.
 	 */
-	private encodeString(lineNo: number, line: string, jumpLabels: Map<string, string>, constants: Map<string, string>) : DoubleWord[] {
+	private encodeString(lineNo: number, line: string, jumpLabels: Map<string, string>, stringValue: string, stringAddress: string) : DoubleWord[] {
 		const encodedInstructions: DoubleWord[] = [];
-		const stringConstantName = line.replace(/const[ ]|[ ]?=[ ]?".*/gim, "");
-		const stringConstantValue = line.replace(/const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?|"/gim, "") + "\0";
-		let stringEncoded = false;
-		if (constants.has(stringConstantName)) {
-			const stringStartAddress: string = constants.get(stringConstantName)!.replace(/^0b/gim, "");
-			const stringMemSize = Math.ceil((Buffer.byteLength(stringConstantValue) / 4)) * 4;
-			//The memory address after the string array with the next instruction
-			const jumpAddress:string = VirtualAddress.fromInteger(parseInt(stringStartAddress, 2) + stringMemSize).toString();
-			const jumpInstruction:string = "JMP @0b" + jumpAddress;
-			const encodedInstruction: DoubleWord[] = this.encodeLine(-1, jumpInstruction, jumpLabels, constants);
-			encodedInstructions.push(...encodedInstruction);
-			//Create a buffer from the string in utf8 encoding and calculate some important values.
-			const stringBuffer = Buffer.from(stringConstantValue, "utf8");
-			const stringByteLength = stringBuffer.length;
-			const continousBufferSegmentSize = stringByteLength - (stringByteLength % 4);
-			const restOfBufferSize = stringByteLength % 4;
-			//Slice the part of the buffer that is divisible by four (in byte) into 32 bit big segments
-			//and encode each segment into binary values.
-			if (continousBufferSegmentSize > 0) {
-				for (let i = 0; i <= stringByteLength - 4; i += 4) {
-					const bufferSegment = stringBuffer.toString("hex", 0 + i, 4 + i);
-					const binaryString = parseInt(bufferSegment, 16).toString(2).padStart(32, "0");
-					const bitArray: Array<Bit> = new Array<Bit>(
-						0, 0, 0, 0,
-						0, 0, 0, 0,
-						0, 0, 0, 0,
-						0, 0, 0, 0,
-						0, 0, 0, 0,
-						0, 0, 0, 0,
-						0, 0, 0, 0,
-						0, 0, 0, 0
-					)
-					binaryString.split("").forEach((bit, index) => {
-						bitArray[index] = (bit === "0") ? 0 : 1;
-					})
-					const encodedStringPart = new DoubleWord(bitArray);
-					encodedInstructions.push(encodedStringPart);
-				}
-			}
-			//Get the last bytes from the buffer
-			if (restOfBufferSize > 0) {
-				const bufferSegment = stringBuffer.toString("hex", continousBufferSegmentSize, stringByteLength);
-				const binaryString = parseInt(bufferSegment, 16).toString(2).padStart((8 * restOfBufferSize), "0");
+		let stringEncoded = false; 
+		const stringStartAddress: string = stringAddress.replace(/^0b/gim, "");
+		const stringMemSize = Math.ceil((Buffer.byteLength(stringValue) / 4)) * 4;
+		//The memory address after the string array with the next instruction
+		const jumpAddress:string = VirtualAddress.fromInteger(parseInt(stringStartAddress, 2) + stringMemSize).toString();
+		const jumpInstruction:string = "JMP @0b" + jumpAddress;
+		const encodedInstruction: DoubleWord[] = this.encodeLine(-1, jumpInstruction, jumpLabels);
+		encodedInstructions.push(...encodedInstruction);
+		//Create a buffer from the string in utf8 encoding and calculate some important values.
+		const stringBuffer = Buffer.from(stringValue, "utf8");
+		const stringByteLength = stringBuffer.length;
+		const continousBufferSegmentSize = stringByteLength - (stringByteLength % 4);
+		const restOfBufferSize = stringByteLength % 4;
+		//Slice the part of the buffer that is divisible by four (in byte) into 32 bit big segments
+		//and encode each segment into binary values.
+		if (continousBufferSegmentSize > 0) {
+			for (let i = 0; i <= stringByteLength - 4; i += 4) {
+				const bufferSegment = stringBuffer.toString("hex", 0 + i, 4 + i);
+				const binaryString = parseInt(bufferSegment, 16).toString(2).padStart(32, "0");
 				const bitArray: Array<Bit> = new Array<Bit>(
 					0, 0, 0, 0,
 					0, 0, 0, 0,
@@ -371,10 +365,31 @@ export class Assembler {
 				const encodedStringPart = new DoubleWord(bitArray);
 				encodedInstructions.push(encodedStringPart);
 			}
-			stringEncoded = true;
 		}
+		//Get the last bytes from the buffer
+		if (restOfBufferSize > 0) {
+			const bufferSegment = stringBuffer.toString("hex", continousBufferSegmentSize, stringByteLength);
+			const binaryString = parseInt(bufferSegment, 16).toString(2).padStart((8 * restOfBufferSize), "0");
+			const bitArray: Array<Bit> = new Array<Bit>(
+				0, 0, 0, 0,
+				0, 0, 0, 0,
+				0, 0, 0, 0,
+				0, 0, 0, 0,
+				0, 0, 0, 0,
+				0, 0, 0, 0,
+				0, 0, 0, 0,
+				0, 0, 0, 0
+			)
+			binaryString.split("").forEach((bit, index) => {
+				bitArray[index] = (bit === "0") ? 0 : 1;
+			})
+			const encodedStringPart = new DoubleWord(bitArray);
+			encodedInstructions.push(encodedStringPart);
+		}
+		stringEncoded = true;
+		
 		if (!stringEncoded) {
-			throw new Error(`Error encoding string constant in line: ${lineNo + 1}: ${line}`);
+			throw new Error(`Error encoding string in line: ${lineNo + 1}: ${line}`);
 		}
 		return encodedInstructions;
 	}

--- a/src/main/simulator/Assembler.ts
+++ b/src/main/simulator/Assembler.ts
@@ -223,7 +223,7 @@ export class Assembler {
 	 * For symbolic variables their (virtual) memory start address gets mapped to their symbolic name.
 	 * @param lines A map, which maps line numbers to strings representing the original programs lines of code.
 	 * @param jumpLabels An empty map, which will be used to store jump labels and their associated (virtual) memory address.
-	 * @param constants An emty map, which will be used to store constants and their associated (virtual) memory address or value.
+	 * @param constants An empty map, which will be used to store constants and their associated (virtual) memory address or value.
 	 * @param variables An empty map, which will be used to store variables and their associated (virtual) memory addresses.
 	 */
 	private locateSymbols(lines: Map<number, string>, jumpLabels: Map<string, string>, constants: Map<string, string>, variables: Map<string, string>) : void {
@@ -237,16 +237,16 @@ export class Assembler {
 			if (line.match(new RegExp(this.languageDefinition.variable_formats.dataSegmentStart)) || line.match(new RegExp(this.languageDefinition.variable_formats.dataSegmentEnd))) {
 				lines.delete(lineNo);
 			} else if (line.match(new RegExp(this.languageDefinition.constant_formats.declarationInteger, "gim"))) {
-				const constantName = line.replace(/const[ ]|[ ]?=[ ]?[0-9]*/gim, "");
-				const constantValue = line.replace(/const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?/gim, "");
+				const constantName = line.replace(/.CONST[ ]|[ ][0-9]*/gim, "");
+				const constantValue = line.replace(/.CONST[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]/gim, "");
 				constants.set(
 					constantName, 
 					constantValue
 				);
 				lines.delete(lineNo);
 			} else if (line.match(new RegExp(this.languageDefinition.constant_formats.declarationString, "gim"))) {
-				const constantName = line.replace(/const[ ]|[ ]?=[ ]?".*/gim, "");
-				const constantValue = line.replace(/const[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]?=[ ]?|"/gim, "") + "\0";
+				const constantName = line.replace(/.CONST[ ]|[ ]".*/gim, "");
+				const constantValue = line.replace(/.CONST[ ][a-zA-Z][a-zA-Z\\-_0-9]*[ ]|"/gim, "") + "\0";
 				//programLocationCounter +12 since the jump instruction will be located in front of the string memory array.
 				constants.set(
 					constantName, 
@@ -347,11 +347,11 @@ export class Assembler {
 		//Create a buffer from the string in utf8 encoding and calculate some important values.
 		const stringBuffer = Buffer.from(stringValue, "utf8");
 		const stringByteLength = stringBuffer.length;
-		const continousBufferSegmentSize = stringByteLength - (stringByteLength % 4);
+		const continuousBufferSegmentSize = stringByteLength - (stringByteLength % 4);
 		const restOfBufferSize = stringByteLength % 4;
 		//Slice the part of the buffer that is divisible by four (in byte) into 32 bit big segments
 		//and encode each segment into binary values.
-		if (continousBufferSegmentSize > 0) {
+		if (continuousBufferSegmentSize > 0) {
 			for (let i = 0; i <= stringByteLength - 4; i += 4) {
 				const bufferSegment = stringBuffer.toString("hex", 0 + i, 4 + i);
 				const binaryString = parseInt(bufferSegment, 16).toString(2).padStart(32, "0");
@@ -374,7 +374,7 @@ export class Assembler {
 		}
 		//Get the last bytes from the buffer
 		if (restOfBufferSize > 0) {
-			const bufferSegment = stringBuffer.toString("hex", continousBufferSegmentSize, stringByteLength);
+			const bufferSegment = stringBuffer.toString("hex", continuousBufferSegmentSize, stringByteLength);
 			const binaryString = parseInt(bufferSegment, 16).toString(2).padStart((8 * restOfBufferSize), "0");
 			const bitArray: Array<Bit> = new Array<Bit>(
 				0, 0, 0, 0,

--- a/src/main/simulator/Assembler.ts
+++ b/src/main/simulator/Assembler.ts
@@ -189,7 +189,7 @@ export class Assembler {
 				encodedInstructions.push(...encodedInstruction);
 				lineEncoded = true;
 			}
-		} else if (line.match(new RegExp(this.languageDefinition.variable_formats.integerVariable))) {
+		} else if (line.match(new RegExp(this.languageDefinition.variable_formats.integerVariable, "gim"))) {
 			const variableName = line.replace(/^\.|[ ][0-9]*$/gim, "");
 			const variableValue = line.replace(/^\.[a-zA-Z][a-zA-Z\\-_0-9]*[ ]?/gim, "");
 			if (variables.has(variableName)) {
@@ -214,13 +214,17 @@ export class Assembler {
 	}
 
 	/**
-	 * Locates the jump labels, constants and variables in the assembly code.
-	 * For the jump labels, integer and string variables and string constants a map is created between their symbolic name and a (virtual) memory address.
-	 * For integer constants their symbolic name gets mapped to their value.
+	 * This method locates symbols in the assembly code and stores them in the appropriate map.
+	 * For jump labels a map between a jump label and a (virtual) memory address is created and the jump label is removed from the code,
+	 * since they won't be translated.
+	 * For symbolic integer constants their value is mapped to their symbolic name and for string constants the (virtual) memory start address gets
+	 * mapped to their symbolic name.
+	 * The lines with symbolic integer constants get removed, since their symbolic name gets replaced by their value later.
+	 * For symbolic variables their (virtual) memory start address gets mapped to their symbolic name.
 	 * @param lines A map, which maps line numbers to strings representing the original programs lines of code.
-	 * @param jumpLabels A map for the jump labels and their associated (virtual) memory address.
-	 * @param constants A map for the constants and their associated (virtual) memory address or value in case of integers.
-	 * @param variables A map for the variables and their associated (virtual) memory address.
+	 * @param jumpLabels An empty map, which will be used to store jump labels and their associated (virtual) memory address.
+	 * @param constants An emty map, which will be used to store constants and their associated (virtual) memory address or value.
+	 * @param variables An empty map, which will be used to store variables and their associated (virtual) memory addresses.
 	 */
 	private locateSymbols(lines: Map<number, string>, jumpLabels: Map<string, string>, constants: Map<string, string>, variables: Map<string, string>) : void {
 		/**
@@ -252,7 +256,7 @@ export class Assembler {
 				//is divisible by four. This insures the string always fits into multiple double words.
 				const stringMemSize = Math.ceil((Buffer.byteLength(constantValue) / 4)) * 4;
 				programLocationCounter += stringMemSize + 12;
-			} else if (line.match(new RegExp(this.languageDefinition.variable_formats.integerVariable))) {
+			} else if (line.match(new RegExp(this.languageDefinition.variable_formats.integerVariable, "gim"))) {
 				const variableName = line.replace(/^.|[ ][0-9]*$/gim, "");
 				//programLocationCounter +12 since the jump instruction will be located in front of the integer memory address.
 				variables.set(
@@ -261,7 +265,7 @@ export class Assembler {
 				);
 				//Size of jump instruction plus 32bit integer
 				programLocationCounter += 16;
-			} else if (line.match(new RegExp(this.languageDefinition.variable_formats.stringVariable))) {
+			} else if (line.match(new RegExp(this.languageDefinition.variable_formats.stringVariable, "gim"))) {
 				const variableName = line.replace(/^.|[ ]".*/gim, "");
 				const variableValue = line.replace(/^\.[a-zA-Z][a-zA-Z\\-_0-9]*[ ]"|"$/gim, "") + "\0";
 				variables.set(
@@ -286,12 +290,13 @@ export class Assembler {
 	}
 
 	/**
-	 * This method finds the usage of symbolic names for the constants and variables in the assembly code and replaces them.
-	 * Integer constants get replaced by their value while string constants, string variables and integer variables get replaced by their
-	 * (virtual) memory start address.
+	 * This method replaces the symbolic names of variables or constants in the assembly code with their associated value or 
+	 * (virtual) memory address.
+	 * Symbolic integer constants get replaced by their value.
+	 * Symbolic integer strings and symbolic variables get replaced by their associated (virtual) memory address.
 	 * @param lines A map, which maps line numbers to strings representing the original programs lines of code.
-	 * @param constants A map for the constants and their associated (virtual) memory address or value in case of integers.
-	 * @param variables A map for the variables and their associated (virtual) memory address.
+	 * @param constants A map, which maps the symbolic name of constants to their value or (virtual) memory start address.
+	 * @param variables A map, which maps the symbolic name of variables to their (virtual) memory start address.
 	 * @returns 
 	 */
 	private replaceSymbols(lines: Map<number, string>, constants: Map<string, string>, variables: Map<string, string>) : Map<number, string> {
@@ -325,7 +330,8 @@ export class Assembler {
 	 * @param lineNo The original computer programs line number of code which is currently encoded.
 	 * @param line The original computer programs line of code which is currently encoded.
 	 * @param jumpLabels The jump labels found in the assembly code.
-	 * @param constants A map of the names of constants and their corresponding value in case of integer or (virtual) memory start address in case of strings.
+	 * @param stringValue The string content.
+	 * @param stringAddress The (virtual) memory start address of the string.
 	 * @returns An array containing the binary equivalent of the given instruction and its operand values.
 	 */
 	private encodeString(lineNo: number, line: string, jumpLabels: Map<string, string>, stringValue: string, stringAddress: string) : DoubleWord[] {

--- a/src/main/simulator/compiler/AssemblyLanguageDefinition.ts
+++ b/src/main/simulator/compiler/AssemblyLanguageDefinition.ts
@@ -1,4 +1,12 @@
 export interface AssemblyLanguageDefinition {
+    variable_formats: {
+        dataSegmentStart: string;
+        dataSegmentEnd: string;
+        integerVariable: string;
+        stringVariable: string;
+        usage: string;
+    }
+    
     constant_formats: {
         declarationInteger: string;
         declarationString: string;

--- a/src/main/simulator/execution_units/CPUCore.ts
+++ b/src/main/simulator/execution_units/CPUCore.ts
@@ -2375,6 +2375,7 @@ export class CPUCore {
      * This method does nothing.
      */
     private nop(): void {
+        this.eflags.enterKernelMode();
         return;
     }
 

--- a/src/main/simulator/execution_units/CPUCore.ts
+++ b/src/main/simulator/execution_units/CPUCore.ts
@@ -2375,6 +2375,7 @@ export class CPUCore {
      * This method does nothing.
      */
     private nop(): void {
+        //Patch to enter kernel mode. Only temporary.
         this.eflags.enterKernelMode();
         return;
     }

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1011,7 +1011,7 @@ export class Renderer {
                 case "ebx":
                     eventListener = this.onChangeListenerEBX;
                     break;
-                case "edx":
+                case "ecx":
                     eventListener = this.onChangeListenerECX;
                     break;
                 case "vmptr":


### PR DESCRIPTION
It is possible to use symbolic variables in the assembly code of the simulator.
An example could look like this:

NOP
.DATA
.X ; 32 Bit uninitialized numerical value
.SUM 0 ; 32 Bit initialized numerical value
.MYNAME "ABCD" ; Array of initialized UTF8 encoded characters plus null terminator
(MYNAME is the address of the first character)
.CODE ; Marks the start of the program code

Data and code sections can alternate.

In the current implementation a patched NOP instruction is needed. Please refer to the included documentation for more information.

closes: #31 